### PR TITLE
Modify script in dtrace.md

### DIFF
--- a/book/tools/dtrace.md
+++ b/book/tools/dtrace.md
@@ -57,8 +57,9 @@ ID    PROVIDER        MODULE      FUNCTION NAME
 Let's create script `test.d` with following contents:
 
 ```
-#!/usr/sbin/dtrace -qs -x dynvarsize=64m
+#!/usr/sbin/dtrace -qs
 #pragma D option flowindent
+#pragma D option dynvarsize=64m
 
 syscall::write:entry
 /pid == $target/    


### PR DESCRIPTION
Running original script on `FreeBSD` will generate  following error:  

    dtrace: failed to open  -x dynvarsize=64m: No such file or directory

Even though `Solaris/illumos` don't complain, the cause is `-x dynvarsize=64m` is ignored, and only `-s` is processed. (Please refer this [comment](https://lists.freebsd.org/pipermail/freebsd-dtrace/2017-July/000537.html))

You can also scan the whole [discussion](https://lists.freebsd.org/pipermail/freebsd-dtrace/2017-July/000536.html), thanks!